### PR TITLE
cast non vararg to object & reduce score client size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 build
 out
+bin

--- a/example/src/main/java/foundation/icon/score/example/HelloWorldImpl.java
+++ b/example/src/main/java/foundation/icon/score/example/HelloWorldImpl.java
@@ -146,6 +146,12 @@ public class HelloWorldImpl implements HelloWorld, IcxTransfer {
         enumerableDictDB.remove(_key);
     }
 
+    @External
+    public void dummyNonVarArg(Address[] addressArray) {}
+
+    @External
+    public void dummyVarArg(Address... varArgAddress) {}
+
     @External(readonly = true)
     public String getEnumerable(String _key) {
         return enumerableDictDB.get(_key);

--- a/example/src/main/java/foundation/icon/score/example/IcxTransfer.java
+++ b/example/src/main/java/foundation/icon/score/example/IcxTransfer.java
@@ -30,8 +30,10 @@ public interface IcxTransfer {
     @External
     void transfer(Address _address);
 
-    @External(readonly = true)
     BigInteger getTransferred(Address _address);
+
+    void dummyNonVarArg(Address[] addressArray);
+    void dummyVarArg(Address... varArgAddress);
 
     @EventLog(indexed = 1)
     void Transferred(Address _from, BigInteger icx);

--- a/score-client/src/main/java/foundation/icon/score/client/ScoreInterfaceProcessor.java
+++ b/score-client/src/main/java/foundation/icon/score/client/ScoreInterfaceProcessor.java
@@ -116,10 +116,6 @@ public class ScoreInterfaceProcessor extends AbstractProcessor {
                 .classBuilder(ClassName.get(interfaceClassName.packageName(), className.simpleName()))
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
 
-        if (element.getKind().isInterface()) {
-            builder.addSuperinterface(element.asType());
-        }
-
         //Fields
         builder.addField(Address.class, MEMBER_ADDRESS, Modifier.PROTECTED, Modifier.FINAL);
 
@@ -194,9 +190,16 @@ public class ScoreInterfaceProcessor extends AbstractProcessor {
         StringJoiner variables = new StringJoiner(", ");
         variables.add(String.format("this.%s", MEMBER_ADDRESS));
         variables.add(String.format("\"%s\"", element.getSimpleName().toString()));
+
         for (VariableElement variableElement : element.getParameters()) {
-            variables.add(variableElement.getSimpleName().toString());
+            String variableName = variableElement.getSimpleName().toString();
+            if (variableElement.asType().getKind() == TypeKind.ARRAY && !element.isVarArgs()) {
+                variableName = "(Object) " + variableName;
+            }
+
+            variables.add(variableName);
         }
+
         return variables.toString();
     }
 
@@ -211,7 +214,6 @@ public class ScoreInterfaceProcessor extends AbstractProcessor {
 
         MethodSpec.Builder builder = MethodSpec
                 .methodBuilder(methodName)
-//                .addAnnotation(Override.class)
                 .addModifiers(ProcessorUtil.getModifiers(ee, Modifier.ABSTRACT))
                 .addParameters(ProcessorUtil.getParameterSpecs(ee))
                 .returns(returnTypeName);


### PR DESCRIPTION
2 potential changes id like to discuss
* Removing inheritance for scoreClientInterfaces and such removing need for the orginal interfaces to be deployed
* Casting arrays into Object to differentiate between varArg and array methods.  